### PR TITLE
Update duckdb dependency in `package.json` to v0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "duckdb-async",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "duckdb-async",
-      "version": "0.7.1",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "duckdb": "0.8.0"
+        "duckdb": "0.8.1"
       },
       "devDependencies": {
         "@types/jest": "^29.2.0",
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.0.tgz",
-      "integrity": "sha512-hD05w83kdDkmRZoKwFK4PiA2fByczPp49rY6cREh23NoVHXJ3I4VpROsW8vNC9Gx7KP7lZpWvT7rQ/MHvrWI5g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.1.tgz",
+      "integrity": "sha512-a2SJDuvBVKy5muYFxXTANlqdNX1daF3NHzpqRdrk0Qx5n3Sh7BxL66O+WY9epaDFukiXEpz45sds5T1LaPaHog==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -5734,9 +5734,9 @@
       "dev": true
     },
     "duckdb": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.0.tgz",
-      "integrity": "sha512-hD05w83kdDkmRZoKwFK4PiA2fByczPp49rY6cREh23NoVHXJ3I4VpROsW8vNC9Gx7KP7lZpWvT7rQ/MHvrWI5g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.1.tgz",
+      "integrity": "sha512-a2SJDuvBVKy5muYFxXTANlqdNX1daF3NHzpqRdrk0Qx5n3Sh7BxL66O+WY9epaDFukiXEpz45sds5T1LaPaHog==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb-async",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Promise wrappers for DuckDb NodeJS API",
   "main": "dist/duckdb-async.js",
   "types": "dist/duckdb-async.d.ts",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/motherduckdb/duckdb-async#readme",
   "dependencies": {
-    "duckdb": "0.8.0"
+    "duckdb": "0.8.1"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",


### PR DESCRIPTION
DuckDB dev team recently released their usual minor patch release with all the bug fixes for the DuckDB `v0.8.0` based on additional testing and feedback from their devs and users community.

https://github.com/duckdb/duckdb/releases/v0.8.1

Just like Evidence dev and a few other node.js based DuckDB tools in the wild, we've decided to use your `duckdb-async` with promises node.js lib wrapper.

We'd like to update our DuckDB Pro Data Tools to support the latest and greatest DuckDB v0.8.1 has to offer.

Please review, test, and merge to make that possible for the users of your `duckdb-async` library, and DuckDB for NodeJS in general.

Thank you!