### PR TITLE
Bump to 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "duckdb-async",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "duckdb-async",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "duckdb": "0.8.0"
+        "duckdb": "0.8.1"
       },
       "devDependencies": {
         "@types/jest": "^29.2.0",
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.0.tgz",
-      "integrity": "sha512-hD05w83kdDkmRZoKwFK4PiA2fByczPp49rY6cREh23NoVHXJ3I4VpROsW8vNC9Gx7KP7lZpWvT7rQ/MHvrWI5g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.1.tgz",
+      "integrity": "sha512-a2SJDuvBVKy5muYFxXTANlqdNX1daF3NHzpqRdrk0Qx5n3Sh7BxL66O+WY9epaDFukiXEpz45sds5T1LaPaHog==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -5734,9 +5734,9 @@
       "dev": true
     },
     "duckdb": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.0.tgz",
-      "integrity": "sha512-hD05w83kdDkmRZoKwFK4PiA2fByczPp49rY6cREh23NoVHXJ3I4VpROsW8vNC9Gx7KP7lZpWvT7rQ/MHvrWI5g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.1.tgz",
+      "integrity": "sha512-a2SJDuvBVKy5muYFxXTANlqdNX1daF3NHzpqRdrk0Qx5n3Sh7BxL66O+WY9epaDFukiXEpz45sds5T1LaPaHog==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "duckdb-async",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "duckdb-async",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "duckdb": "0.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb-async",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Promise wrappers for DuckDb NodeJS API",
   "main": "dist/duckdb-async.js",
   "types": "dist/duckdb-async.d.ts",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/motherduckdb/duckdb-async#readme",
   "dependencies": {
-    "duckdb": "0.8.0"
+    "duckdb": "0.8.1"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",


### PR DESCRIPTION
## Test output
```
~/Projects/duckdb-async$ npm run test
Debugger attached.

> duckdb-async@0.8.1 test
> jest --config jest.config.json --no-cache

Debugger attached.
 PASS  test/basic.test.ts
  ✓ t0 - basic database create (27 ms)
  Async API points
    ✓ Database.create -- read only flag (3 ms)
    ✓ Database.all -- basic query (3 ms)
    ✓ Database.all -- erroneous query (12 ms)
    ✓ Database.exec -- multiple statements (and verify results) (3 ms)
    ✓ basic connect and Connection.all (1 ms)
    ✓ basic statement prepare/run/finalize
    ✓ Statement.all
    ✓ prepareSync (1 ms)
    ✓ ternary int udf (1 ms)
    ✓ basic stream test (2 ms)
    ✓ arrowIPCAll (20 ms)
    ✓ Database.close (3 ms)

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        1.018 s
Ran all test suites.
```