### PR TITLE
Set user_agent to `nodejs-async`

### DIFF
--- a/src/duckdb-async.ts
+++ b/src/duckdb-async.ts
@@ -294,7 +294,11 @@ export class Database {
     resolve: (db: Database) => void,
     reject: (reason: any) => void
   ) {
-    this.db = new duckdb.Database(path, accessMode, (err, res) => {
+    const config = {
+      access_mode: accessMode == duckdb.OPEN_READONLY ? "read_only" : "read_write",
+      duckdb_api: 'nodejs-async'
+    };
+    this.db = new duckdb.Database(path, config, (err, res) => {
       if (err) {
         reject(err);
       }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -25,6 +25,19 @@ describe("Async API points", () => {
     }
   });
 
+  test("Database.create -- explicit read/write flag", async () => {
+    const rwDb = await Database.create(":memory:", duckdb.OPEN_READWRITE);
+    await rwDb.exec("CREATE TABLE foo (txt text, num int, flt double, blb blob)");
+    const empty_result = await rwDb.all("SELECT * FROM foo");
+    expect(empty_result.length).toBe(0);
+  });
+
+  test("Database.create -- user agent", async () => {
+    const rwDb = await Database.create(":memory:");
+    const user_agent = await rwDb.all("PRAGMA user_agent");
+    expect(user_agent[0]["user_agent"]).toMatch(/duckdb\/[^ ]* nodejs-async/);
+  });
+
   test("Database.all -- basic query", async () => {
     const results = await db.all("select 42 as a");
     expect(results.length).toBe(1);


### PR DESCRIPTION
I've set `duckdb_api` property rather than `custom_user_agent` because using `duckdb-async` always implies using `duckdb-node`, so having both would be redundant (`custom_user_agent` is additive, while `duckdb_api` is a single value).

`duckdb-node` when used without `nodejs-async` will have a user-agent of `nodejs` ([PR](https://github.com/duckdb/duckdb-node/pull/44)).