### PR TITLE
Set user_agent to `nodejs-async` in 0.10.0

### DIFF
--- a/src/duckdb-async.ts
+++ b/src/duckdb-async.ts
@@ -307,6 +307,13 @@ export class Database {
     resolve: (db: Database) => void,
     reject: (reason: any) => void
   ) {
+    if (typeof accessMode === "number") {
+      accessMode = {
+        access_mode: accessMode == duckdb.OPEN_READONLY ? "read_only" : "read_write"
+      };
+    }
+    accessMode["duckdb_api"] = "nodejs-async";
+
     this.db = new duckdb.Database(path, accessMode, (err, res) => {
       if (err) {
         reject(err);

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -31,6 +31,23 @@ describe("Async API points", () => {
       max_memory: "512MB",
       threads: "4",
     });
+    const user_agent = await rwOptsDb.all("PRAGMA user_agent");
+    expect(user_agent[0]["user_agent"]).toMatch(/duckdb\/[^ ]* nodejs-async/);
+  });
+
+  test("Database.create -- explicit numeric read/write flag", async () => {
+    const rwDb = await Database.create(":memory:", duckdb.OPEN_READWRITE);
+    await rwDb.exec("CREATE TABLE foo (txt text, num int, flt double, blb blob)");
+    const empty_result = await rwDb.all("SELECT * FROM foo");
+    expect(empty_result.length).toBe(0);
+    const user_agent = await rwDb.all("PRAGMA user_agent");
+    expect(user_agent[0]["user_agent"]).toMatch(/duckdb\/[^ ]* nodejs-async/);
+  });
+
+  test("Database.create -- user agent", async () => {
+    const rwDb = await Database.create(":memory:");
+    const user_agent = await rwDb.all("PRAGMA user_agent");
+    expect(user_agent[0]["user_agent"]).toMatch(/duckdb\/[^ ]* nodejs-async/);
   });
 
   test("Database.all -- basic query", async () => {


### PR DESCRIPTION
I've set `duckdb_api` property rather than `custom_user_agent` because using `duckdb-async` always implies using `duckdb-node`, so having both would be redundant (`custom_user_agent` is additive, while `duckdb_api` is a single value).

`duckdb-node` when used without `nodejs-async` will have a user-agent of `nodejs` ([PR](https://github.com/duckdb/duckdb-node/pull/44)).