### PR TITLE
chore: upgrade duckdb to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
-        "duckdb": "0.10.2"
+        "duckdb": "1.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.2.0",
@@ -1816,9 +1816,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.10.2.tgz",
-      "integrity": "sha512-7UGLRp+zkAzE0AQjyUfOyEjuX7Xs3St452+ZtUSbQEE8DJjc6GUWscxYPm5XPe5fX4nL+Zy9lVMEss1Yuw74kA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.0.0.tgz",
+      "integrity": "sha512-QwpcIeN42A2lL19S70mUFibZgRcEcZpCkKHdzDgecHaYZhXj3+1i2cxSDyAk/RVg5CYnqj1Dp4jAuN4cc80udA==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/motherduckdb/duckdb-async#readme",
   "dependencies": {
-    "duckdb": "0.10.2"
+    "duckdb": "1.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",


### PR DESCRIPTION
Upgrade duckdb to 1.0.0 following todays release