### PR TITLE
chore: bump duckdb to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "duckdb-async",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "duckdb-async",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "duckdb": "1.0.0"
+        "duckdb": "1.1.0"
       },
       "devDependencies": {
         "@types/jest": "^29.2.0",
@@ -1816,10 +1816,11 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.0.0.tgz",
-      "integrity": "sha512-QwpcIeN42A2lL19S70mUFibZgRcEcZpCkKHdzDgecHaYZhXj3+1i2cxSDyAk/RVg5CYnqj1Dp4jAuN4cc80udA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.1.0.tgz",
+      "integrity": "sha512-T814+D3H8y1bCidJP5QxnIoE0UC6ETbEctFPyIEkCt1byPioKpiuNy8ieY2GqG5ZXTMLkaynNo1JZ7pev+B0Rg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "duckdb-async",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Promise wrappers for DuckDb NodeJS API",
   "main": "dist/duckdb-async.js",
   "types": "dist/duckdb-async.d.ts",
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/motherduckdb/duckdb-async#readme",
   "dependencies": {
-    "duckdb": "1.0.0"
+    "duckdb": "1.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.0",


### PR DESCRIPTION
Dumping duckdb version so that the fixes for the follow issue can be resolved: https://github.com/duckdb/duckdb/issues/13272